### PR TITLE
fix: patch path traversal and TOCTOU race conditions

### DIFF
--- a/internal/repository/helpers.go
+++ b/internal/repository/helpers.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 
 	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgconn"
 
 	"github.com/chuanghiduoc/fiber-golang-boilerplate/pkg/apperror"
 )
@@ -15,4 +16,10 @@ func wrapErr(err error) error {
 		return apperror.ErrNotFound
 	}
 	return err
+}
+
+// IsUniqueViolation checks whether the error is a PostgreSQL unique constraint violation (23505).
+func IsUniqueViolation(err error) bool {
+	var pgErr *pgconn.PgError
+	return errors.As(err, &pgErr) && pgErr.Code == "23505"
 }

--- a/internal/repository/password_reset_repository.go
+++ b/internal/repository/password_reset_repository.go
@@ -9,6 +9,7 @@ import (
 type PasswordResetRepository interface {
 	Create(ctx context.Context, params sqlc.CreatePasswordResetTokenParams) (*sqlc.PasswordResetToken, error)
 	GetByToken(ctx context.Context, token string) (*sqlc.PasswordResetToken, error)
+	GetByTokenForUpdate(ctx context.Context, token string) (*sqlc.PasswordResetToken, error)
 	Delete(ctx context.Context, token string) error
 	DeleteByUserID(ctx context.Context, userID int64) error
 }
@@ -31,6 +32,14 @@ func (r *passwordResetRepository) Create(ctx context.Context, params sqlc.Create
 
 func (r *passwordResetRepository) GetByToken(ctx context.Context, token string) (*sqlc.PasswordResetToken, error) {
 	rt, err := r.q.GetPasswordResetTokenByToken(ctx, token)
+	if err != nil {
+		return nil, wrapErr(err)
+	}
+	return &rt, nil
+}
+
+func (r *passwordResetRepository) GetByTokenForUpdate(ctx context.Context, token string) (*sqlc.PasswordResetToken, error) {
+	rt, err := r.q.GetPasswordResetTokenByTokenForUpdate(ctx, token)
 	if err != nil {
 		return nil, wrapErr(err)
 	}

--- a/internal/service/mocks_test.go
+++ b/internal/service/mocks_test.go
@@ -362,6 +362,10 @@ func (m *mockPasswordResetRepo) GetByToken(_ context.Context, token string) (*sq
 	return t, nil
 }
 
+func (m *mockPasswordResetRepo) GetByTokenForUpdate(ctx context.Context, token string) (*sqlc.PasswordResetToken, error) {
+	return m.GetByToken(ctx, token)
+}
+
 func (m *mockPasswordResetRepo) Delete(_ context.Context, token string) error {
 	delete(m.tokens, token)
 	return nil

--- a/internal/sqlc/password_reset_token.sql.go
+++ b/internal/sqlc/password_reset_token.sql.go
@@ -70,3 +70,20 @@ func (q *Queries) GetPasswordResetTokenByToken(ctx context.Context, token string
 	)
 	return i, err
 }
+
+const getPasswordResetTokenByTokenForUpdate = `-- name: GetPasswordResetTokenByTokenForUpdate :one
+SELECT id, user_id, token, expires_at, created_at FROM password_reset_tokens WHERE token = $1 FOR UPDATE
+`
+
+func (q *Queries) GetPasswordResetTokenByTokenForUpdate(ctx context.Context, token string) (PasswordResetToken, error) {
+	row := q.db.QueryRow(ctx, getPasswordResetTokenByTokenForUpdate, token)
+	var i PasswordResetToken
+	err := row.Scan(
+		&i.ID,
+		&i.UserID,
+		&i.Token,
+		&i.ExpiresAt,
+		&i.CreatedAt,
+	)
+	return i, err
+}

--- a/pkg/storage/local.go
+++ b/pkg/storage/local.go
@@ -6,6 +6,7 @@ import (
 	"io"
 	"os"
 	"path/filepath"
+	"strings"
 )
 
 type LocalStorage struct {
@@ -25,8 +26,57 @@ func NewLocalStorage(basePath string) (*LocalStorage, error) {
 	return &LocalStorage{basePath: abs}, nil
 }
 
-func (s *LocalStorage) Put(_ context.Context, path string, reader io.Reader, _ int64, _ string) error {
+func (s *LocalStorage) safePath(path string) (string, error) {
 	fullPath := filepath.Join(s.basePath, path)
+
+	resolved, err := filepath.EvalSymlinks(fullPath)
+	if err != nil {
+		resolved, err = resolveExistingPrefix(fullPath)
+		if err != nil {
+			return "", fmt.Errorf("invalid path: %w", err)
+		}
+	}
+
+	if !strings.HasPrefix(resolved, s.basePath+string(filepath.Separator)) && resolved != s.basePath {
+		return "", fmt.Errorf("path traversal detected")
+	}
+	return resolved, nil
+}
+
+// resolveExistingPrefix resolves symlinks on the longest existing ancestor of
+// the given path, then appends the remaining non-existent suffix. This prevents
+// symlink bypass when intermediate directories are symlinks but the final target
+// does not yet exist.
+func resolveExistingPrefix(fullPath string) (string, error) {
+	current := fullPath
+	var suffix string
+	for {
+		resolved, err := filepath.EvalSymlinks(current)
+		if err == nil {
+			return filepath.Join(resolved, suffix), nil
+		}
+		parent := filepath.Dir(current)
+		if parent == current {
+			abs, err := filepath.Abs(fullPath)
+			if err != nil {
+				return "", err
+			}
+			return abs, nil
+		}
+		if suffix == "" {
+			suffix = filepath.Base(current)
+		} else {
+			suffix = filepath.Join(filepath.Base(current), suffix)
+		}
+		current = parent
+	}
+}
+
+func (s *LocalStorage) Put(_ context.Context, path string, reader io.Reader, _ int64, _ string) error {
+	fullPath, err := s.safePath(path)
+	if err != nil {
+		return err
+	}
 
 	dir := filepath.Dir(fullPath)
 	if err := os.MkdirAll(dir, 0o750); err != nil {
@@ -47,7 +97,10 @@ func (s *LocalStorage) Put(_ context.Context, path string, reader io.Reader, _ i
 }
 
 func (s *LocalStorage) Get(_ context.Context, path string) (io.ReadCloser, error) {
-	fullPath := filepath.Join(s.basePath, path)
+	fullPath, err := s.safePath(path)
+	if err != nil {
+		return nil, err
+	}
 
 	f, err := os.Open(fullPath)
 	if err != nil {
@@ -58,7 +111,10 @@ func (s *LocalStorage) Get(_ context.Context, path string) (io.ReadCloser, error
 }
 
 func (s *LocalStorage) Delete(_ context.Context, path string) error {
-	fullPath := filepath.Join(s.basePath, path)
+	fullPath, err := s.safePath(path)
+	if err != nil {
+		return err
+	}
 
 	if err := os.Remove(fullPath); err != nil && !os.IsNotExist(err) {
 		return fmt.Errorf("failed to delete file: %w", err)
@@ -68,5 +124,9 @@ func (s *LocalStorage) Delete(_ context.Context, path string) error {
 }
 
 func (s *LocalStorage) URL(path string) string {
+	cleaned := filepath.ToSlash(filepath.Clean(path))
+	if cleaned == "." || strings.HasPrefix(cleaned, "../") || strings.Contains(cleaned, "/../") {
+		return "/uploads/"
+	}
 	return "/uploads/" + path
 }

--- a/queries/password_reset_token.sql
+++ b/queries/password_reset_token.sql
@@ -6,6 +6,9 @@ RETURNING *;
 -- name: GetPasswordResetTokenByToken :one
 SELECT * FROM password_reset_tokens WHERE token = $1;
 
+-- name: GetPasswordResetTokenByTokenForUpdate :one
+SELECT * FROM password_reset_tokens WHERE token = $1 FOR UPDATE;
+
 -- name: DeletePasswordResetToken :exec
 DELETE FROM password_reset_tokens WHERE token = $1;
 


### PR DESCRIPTION
## Summary

- **Path traversal in LocalStorage**: Added `safePath()` validation to `Put`, `Get`, `Delete` — ensures resolved path stays within `basePath`, preventing `../../` escape attacks
- **TOCTOU race in FindOrCreateByGoogle**: Moved `GetByGoogleID` lookup inside the transaction so the entire find→link/create flow is atomic, preventing duplicate user creation from concurrent OAuth callbacks
- **TOCTOU race in ResetPassword**: Moved token validation (`GetByToken` + expiry check) inside the transaction callback so validate→update→delete is atomic, preventing double-reset with the same token

## Test plan

- [x] `go build ./...` — compiles without errors
- [x] `go test ./... -v` — all 47 tests pass (handler, service, token, validator)
- [x] Manual test: attempt path traversal with `../../` in upload path — should return error
- [x] Manual test: concurrent Google OAuth callbacks with same account — should not create duplicates
- [x] Manual test: concurrent password reset with same token — only one should succeed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Security**
  * Enhanced local file storage to prevent path traversal and ensure safer file access.

* **Stability**
  * Made password reset fully atomic to eliminate race conditions and improve reliability.
  * Improved OAuth (Google) sign-in flow to handle concurrent account linking/creation more robustly.

* **Bug Fixes**
  * Better handling of duplicate account creation errors to reduce sign-in failures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->