### PR TITLE
fix(security): update Go 1.25.7 → 1.25.8 to patch 3 stdlib vulnerabilities

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/chuanghiduoc/fiber-golang-boilerplate
 
-go 1.25.7
+go 1.25.8
 
 require (
 	github.com/caarlos0/env/v11 v11.4.0


### PR DESCRIPTION
## Summary
- Update Go version from `1.25.7` to `1.25.8` in `go.mod` to fix 3 standard library vulnerabilities detected by `govulncheck`

## Vulnerabilities Fixed
| ID | Package | Description |
|---|---|---|
| GO-2026-4603 | `html/template` | URLs in meta content attribute actions are not escaped |
| GO-2026-4602 | `os` | FileInfo can escape from a Root |
| GO-2026-4601 | `net/url` | Incorrect parsing of IPv6 host literals |

## Test plan
- [x] `go mod tidy` runs successfully
- [x] CI passes
- [x] `govulncheck ./...` reports no stdlib vulnerabilities

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Go compiler to version 1.25.8, which includes bug fixes and performance improvements for the build environment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->