### PR TITLE
chore: bump Go toolchain to 1.26.4 for stdlib security fixes

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/chuanghiduoc/fiber-golang-boilerplate
 
-go 1.26.2
+go 1.26.4
 
 require (
 	github.com/caarlos0/env/v11 v11.4.1


### PR DESCRIPTION
## Mục đích

Nâng Go toolchain từ `1.26.2` lên `1.26.4` để vá các lỗ hổng trong standard library mà `govulncheck` phát hiện (Security CI job).

## Lỗ hổng được vá (stdlib)

- **GO-2026-5039** — `net/textproto`: arbitrary input chưa escape trong errors (fixed in 1.26.4)
- **GO-2026-5038** — `mime`: quadratic complexity trong `WordDecoder.DecodeHeader` (fixed in 1.26.4)
- **GO-2026-5037** — `crypto/x509`: parsing hostname không hiệu quả (fixed in 1.26.4)
- **GO-2026-4986** — `net/mail`: quadratic string concat trong `consumeComment` (fixed in 1.26.3)
- **GO-2026-4982 / 4980** — `html/template`: bypass escaping dẫn tới XSS (fixed in 1.26.3)

## Thay đổi

- `go.mod`: `go 1.26.2` → `go 1.26.4`

CI dùng `go-version-file: go.mod` nên `setup-go` sẽ tự cài đúng patch. Dockerfile dùng tag floating `golang:1.26-alpine` (tự lấy patch mới nhất), không cần đổi.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Updated Go toolchain to version 1.26.4 for improved compatibility and stability enhancements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->