### PR TITLE
chore: bump go directive to 1.26.5

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/chuanghiduoc/fiber-golang-boilerplate
 
-go 1.26.4
+go 1.26.5
 
 require (
 	github.com/caarlos0/env/v11 v11.4.1


### PR DESCRIPTION
## What

Bumps the `go` directive in `go.mod` from `1.26.4` to `1.26.5`. One-line change, no dependency or code changes.

## Why

The `Security` job (`govulncheck ./...`) has been failing on every open PR with:

```
Vulnerability #1: GO-2026-5856
    Invoking Encrypted Client Hello privacy leak in crypto/tls
    Found in: crypto/tls@go1.26.4
    Fixed in: crypto/tls@go1.26.5
```

Reachable from `pkg/oauth/google.go`, `pkg/storage/local.go`, `pkg/email/smtp.go` and `pkg/cache/redis.go`. It is a standard-library vulnerability, so no dependency bump can fix it — the only fix is moving off go1.26.4.

CI resolves the toolchain via `setup-go` with `go-version-file: go.mod` and `GOTOOLCHAIN: local`, so the `go` directive is the single source of truth for the version govulncheck scans.

## Verified locally (go1.26.5)

- `go build ./...` — pass
- `go vet ./...` — pass
- `go test ./...` — pass (all packages)
- `golangci-lint run` — 0 issues
- `govulncheck ./...` — GO-2026-5856 gone

## Known: `Security` will still be red on this PR

`govulncheck` now surfaces a second, unrelated finding:

```
GO-2026-5970 — Infinite loop on invalid input in golang.org/x/text
    Found in: golang.org/x/text@v0.38.0   Fixed in: golang.org/x/text@v0.39.0
```

That one is fixed by Dependabot PR #55 (bumps `x/text` to v0.40.0), which is queued right behind this. `Security` is not a required check; `Lint` and `Test` are.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the underlying Go toolchain version to 1.26.5.
  * No user-facing functionality or dependency changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->